### PR TITLE
Wrong link to bluesky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Bluesky Overhaul
 
-This is a small (and hopefully temporary) extension for Chrome that adds some nice and handy features to [Bluesky](https://bluesky.app/), the greatest media platform of all time.
+This is a small (and hopefully temporary) extension for Chrome that adds some nice and handy features to [Bluesky](https://bsky.app/), the greatest media platform of all time.
 
 Right now (as of April 11, 2023), the app is invite-only and the web app is running at https://staging.bsky.app/ (you may find yours truly at [@blisstweeting.ingroup.social](https://staging.bsky.app/profile/blisstweeting.ingroup.social)).
 


### PR DESCRIPTION
Link went to bluesky.app instead of bsky.app, which is some other company